### PR TITLE
Add queue and TLS utilities

### DIFF
--- a/cs/rqbench/Atomic.cs
+++ b/cs/rqbench/Atomic.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Threading;
+
+public class AtomicMonotonicUInt64
+{
+    private ulong _value;
+    private readonly object _lock = new();
+
+    public ulong Load()
+    {
+        lock (_lock)
+        {
+            return _value;
+        }
+    }
+
+    public void Store(ulong v)
+    {
+        lock (_lock)
+        {
+            if (v > _value)
+                _value = v;
+        }
+    }
+
+    public void Reset()
+    {
+        lock (_lock)
+        {
+            _value = 0;
+        }
+    }
+}
+
+public class AtomicTime
+{
+    private DateTime _time;
+    private readonly ReaderWriterLockSlim _lock = new();
+
+    public void Store(DateTime t)
+    {
+        _lock.EnterWriteLock();
+        try
+        {
+            _time = t;
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    public DateTime Load()
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            return _time;
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
+    public void Add(TimeSpan d)
+    {
+        _lock.EnterWriteLock();
+        try
+        {
+            _time = _time.Add(d);
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    public TimeSpan Sub(AtomicTime t)
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            return _time - t._time;
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
+    public bool IsZero()
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            return _time == default;
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+}
+
+public class AtomicBool
+{
+    private int _state; // 1 true, 0 false
+
+    public void Set() => Interlocked.Exchange(ref _state, 1);
+    public void Unset() => Interlocked.Exchange(ref _state, 0);
+    public bool Is() => Interlocked.CompareExchange(ref _state, 0, 0) == 1;
+}
+
+public class AtomicString
+{
+    private string _value = string.Empty;
+    private readonly ReaderWriterLockSlim _lock = new();
+
+    public void Store(string s)
+    {
+        _lock.EnterWriteLock();
+        try
+        {
+            _value = s;
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    public string Load()
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            return _value;
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+}

--- a/cs/rqbench/AutoConfig.cs
+++ b/cs/rqbench/AutoConfig.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+public class S3Config
+{
+    public string Endpoint { get; set; } = string.Empty;
+    public string Region { get; set; } = string.Empty;
+    public string AccessKeyID { get; set; } = string.Empty;
+    public string SecretAccessKey { get; set; } = string.Empty;
+    public string Bucket { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public bool ForcePathStyle { get; set; }
+}
+
+public class BackupConfig
+{
+    public int Version { get; set; }
+    public StorageType Type { get; set; }
+    public bool NoCompress { get; set; }
+    public bool Timestamp { get; set; }
+    public bool Vacuum { get; set; }
+    public Duration Interval { get; set; }
+    public JsonElement Sub { get; set; }
+
+    public static (BackupConfig cfg, S3Config s3) Unmarshal(ReadOnlySpan<byte> data)
+    {
+        var cfg = JsonSerializer.Deserialize<BackupConfig>(data)!;
+        if (cfg.Version > 1) throw new InvalidOperationException("invalid version");
+        var s3 = cfg.Sub.Deserialize<S3Config>();
+        return (cfg, s3 ?? new S3Config());
+    }
+
+    public static byte[] ReadConfigFile(string filename)
+    {
+        var data = File.ReadAllBytes(filename);
+        var expanded = Environment.ExpandEnvironmentVariables(System.Text.Encoding.UTF8.GetString(data));
+        return System.Text.Encoding.UTF8.GetBytes(expanded);
+    }
+}
+
+public class RestoreConfig
+{
+    public int Version { get; set; }
+    public StorageType Type { get; set; }
+    public Duration Timeout { get; set; }
+    public bool ContinueOnFailure { get; set; }
+    public JsonElement Sub { get; set; }
+
+    public static (RestoreConfig cfg, S3Config s3) Unmarshal(ReadOnlySpan<byte> data)
+    {
+        var cfg = JsonSerializer.Deserialize<RestoreConfig>(data)!;
+        if (cfg.Version > 1) throw new InvalidOperationException("invalid version");
+        if (cfg.Timeout.Value == TimeSpan.Zero)
+            cfg.Timeout = TimeSpan.FromSeconds(30);
+        var s3 = cfg.Sub.Deserialize<S3Config>();
+        return (cfg, s3 ?? new S3Config());
+    }
+
+    public static byte[] ReadConfigFile(string filename)
+    {
+        var data = File.ReadAllBytes(filename);
+        var expanded = Environment.ExpandEnvironmentVariables(System.Text.Encoding.UTF8.GetString(data));
+        return System.Text.Encoding.UTF8.GetBytes(expanded);
+    }
+}

--- a/cs/rqbench/CRC32Util.cs
+++ b/cs/rqbench/CRC32Util.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+
+public static class CRC32Util
+{
+    private static readonly uint[] table = CreateTable();
+
+    private static uint[] CreateTable()
+    {
+        var tbl = new uint[256];
+        for (uint i = 0; i < tbl.Length; i++)
+        {
+            uint c = i;
+            for (int j = 0; j < 8; j++)
+            {
+                if ((c & 1) != 0)
+                    c = 0xEDB88320u ^ (c >> 1);
+                else
+                    c >>= 1;
+            }
+            tbl[i] = c;
+        }
+        return tbl;
+    }
+
+    public static uint CRC32(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return CRC32(stream);
+    }
+
+    public static uint CRC32(Stream stream)
+    {
+        uint crc = 0xFFFFFFFFu;
+        int b;
+        while ((b = stream.ReadByte()) != -1)
+        {
+            crc = table[(crc ^ (byte)b) & 0xFF] ^ (crc >> 8);
+        }
+        return crc ^ 0xFFFFFFFFu;
+    }
+}

--- a/cs/rqbench/CertGenerator.cs
+++ b/cs/rqbench/CertGenerator.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+public static class CertGenerator
+{
+    public static (byte[] certPem, byte[] keyPem) GenerateCACert(string subject, TimeSpan validFor, int keySize)
+    {
+        using var rsa = RSA.Create(keySize);
+        var req = new CertificateRequest($"CN={subject}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        req.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, true, 0, true));
+        req.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.DigitalSignature, true));
+        var cert = req.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.Add(validFor));
+        var certPem = PemEncoding.Write("CERTIFICATE", cert.RawData);
+        var keyPem = PemEncoding.Write("RSA PRIVATE KEY", rsa.ExportRSAPrivateKey());
+        return (certPem, keyPem);
+    }
+
+    public static (byte[] certPem, byte[] keyPem) GenerateSelfSignedCert(string subject, TimeSpan validFor, int keySize)
+    {
+        using var rsa = RSA.Create(keySize);
+        var req = new CertificateRequest($"CN={subject}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        req.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, true, 0, true));
+        var cert = req.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.Add(validFor));
+        var certPem = PemEncoding.Write("CERTIFICATE", cert.RawData);
+        var keyPem = PemEncoding.Write("RSA PRIVATE KEY", rsa.ExportRSAPrivateKey());
+        return (certPem, keyPem);
+    }
+}

--- a/cs/rqbench/CertReloader.cs
+++ b/cs/rqbench/CertReloader.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+
+public class CertReloader
+{
+    private readonly string _certPath;
+    private readonly string _keyPath;
+    private DateTime _modTime;
+    private X509Certificate2 _cert;
+    private readonly ReaderWriterLockSlim _lock = new();
+
+    public CertReloader(string certPath, string keyPath)
+    {
+        _certPath = certPath;
+        _keyPath = keyPath;
+        _cert = LoadKeyPair(certPath, keyPath);
+        _modTime = LatestModTime(certPath, keyPath);
+    }
+
+    public X509Certificate2 GetCertificate()
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            var latest = LatestModTime(_certPath, _keyPath);
+            if (latest <= _modTime)
+                return _cert;
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+
+        _lock.EnterWriteLock();
+        try
+        {
+            var latest = LatestModTime(_certPath, _keyPath);
+            if (latest > _modTime)
+            {
+                _cert = LoadKeyPair(_certPath, _keyPath);
+                _modTime = latest;
+            }
+            return _cert;
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    private static X509Certificate2 LoadKeyPair(string cert, string key)
+    {
+        return X509Certificate2.CreateFromPemFile(cert, key);
+    }
+
+    private static DateTime LatestModTime(params string[] files)
+    {
+        DateTime latest = DateTime.MinValue;
+        foreach (var f in files)
+        {
+            var t = File.GetLastWriteTimeUtc(f);
+            if (t > latest) latest = t;
+        }
+        return latest;
+    }
+}

--- a/cs/rqbench/CheckAndSet.cs
+++ b/cs/rqbench/CheckAndSet.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class CheckAndSet
+{
+    private bool _state;
+    private string _owner = string.Empty;
+    private DateTime _startTime;
+    private readonly object _lock = new();
+
+    public void Begin(string owner)
+    {
+        lock (_lock)
+        {
+            if (_state)
+                throw new InvalidOperationException($"CAS conflict: currently held by owner \"{_owner}\" for {DateTime.UtcNow - _startTime}");
+            _owner = owner;
+            _state = true;
+            _startTime = DateTime.UtcNow;
+        }
+    }
+
+    public async Task BeginWithRetry(string owner, TimeSpan timeout, TimeSpan retryInterval)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (true)
+        {
+            try
+            {
+                Begin(owner);
+                return;
+            }
+            catch (InvalidOperationException)
+            {
+                if (DateTime.UtcNow > deadline)
+                    throw new TimeoutException("CAS conflict timeout");
+                await Task.Delay(retryInterval);
+            }
+        }
+    }
+
+    public void End()
+    {
+        lock (_lock)
+        {
+            _owner = string.Empty;
+            _state = false;
+            _startTime = default;
+        }
+    }
+
+    public string Owner
+    {
+        get { lock (_lock) { return _owner; } }
+    }
+
+    public Dictionary<string, object?> Stats()
+    {
+        lock (_lock)
+        {
+            var stats = new Dictionary<string, object?> { ["owner"] = null };
+            if (_state)
+            {
+                stats["owner"] = _owner;
+                stats["duration"] = DateTime.UtcNow - _startTime;
+            }
+            return stats;
+        }
+    }
+}

--- a/cs/rqbench/ConnPool.cs
+++ b/cs/rqbench/ConnPool.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net.Sockets;
+
+public delegate Socket ConnectionFactory();
+
+public interface IPool
+{
+    Socket Get();
+    void Close();
+    int Len { get; }
+    Dictionary<string, object> Stats();
+}
+
+public class PooledConn : IDisposable
+{
+    public Socket Inner { get; }
+    private readonly ChannelPool _pool;
+    private bool _unusable;
+    private readonly object _lock = new();
+
+    public PooledConn(Socket inner, ChannelPool pool)
+    {
+        Inner = inner;
+        _pool = pool;
+    }
+
+    public void MarkUnusable()
+    {
+        lock (_lock)
+        {
+            _unusable = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            if (_unusable)
+            {
+                Inner.Dispose();
+                _pool.DecrementOpen();
+            }
+            else
+            {
+                _pool.Return(Inner);
+            }
+        }
+    }
+}
+
+public class ChannelPool : IPool
+{
+    private readonly ConcurrentQueue<Socket> _conns;
+    private readonly ConnectionFactory _factory;
+    private readonly int _maxCap;
+    private bool _closed;
+    private int _openConns;
+    private readonly object _lock = new();
+
+    public ChannelPool(int maxCap, ConnectionFactory factory)
+    {
+        if (factory == null) throw new ArgumentNullException(nameof(factory));
+        if (maxCap <= 0) throw new ArgumentException("invalid capacity", nameof(maxCap));
+        _factory = factory;
+        _maxCap = maxCap;
+        _conns = new ConcurrentQueue<Socket>();
+    }
+
+    public Socket Get()
+    {
+        if (_closed) throw new InvalidOperationException("pool is closed");
+        if (_conns.TryDequeue(out var conn))
+            return Wrap(conn);
+        lock (_lock)
+        {
+            if (_closed) throw new InvalidOperationException("pool is closed");
+            if (_openConns >= _maxCap)
+            {
+                if (_conns.TryDequeue(out conn))
+                    return Wrap(conn);
+                throw new InvalidOperationException("pool exhausted");
+            }
+            conn = _factory();
+            _openConns++;
+            return Wrap(conn);
+        }
+    }
+
+    private PooledConn Wrap(Socket conn) => new(conn, this);
+
+    internal void Return(Socket conn)
+    {
+        if (_closed || _conns.Count >= _maxCap)
+        {
+            conn.Dispose();
+            DecrementOpen();
+            return;
+        }
+        _conns.Enqueue(conn);
+    }
+
+    internal void DecrementOpen()
+    {
+        lock (_lock) { _openConns--; }
+    }
+
+    public void Close()
+    {
+        lock (_lock)
+        {
+            if (_closed) return;
+            _closed = true;
+        }
+        while (_conns.TryDequeue(out var c))
+        {
+            c.Dispose();
+        }
+        _openConns = 0;
+    }
+
+    public int Len => _conns.Count;
+
+    public Dictionary<string, object> Stats()
+    {
+        return new Dictionary<string, object>
+        {
+            ["idle"] = _conns.Count,
+            ["open_connections"] = _openConns,
+            ["max_open_connections"] = _maxCap
+        };
+    }
+}

--- a/cs/rqbench/CredentialsStore.cs
+++ b/cs/rqbench/CredentialsStore.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+public interface IBasicAuther
+{
+    (string username, string password, bool ok) BasicAuth();
+}
+
+public class Credential
+{
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+    public string[] Perms { get; set; } = Array.Empty<string>();
+}
+
+public class CredentialsStore
+{
+    public const string AllUsers = "*";
+    public const string PermAll = "all";
+    public const string PermJoin = "join";
+    public const string PermJoinReadOnly = "join-read-only";
+    public const string PermRemove = "remove";
+    public const string PermExecute = "execute";
+    public const string PermQuery = "query";
+    public const string PermStatus = "status";
+    public const string PermReady = "ready";
+    public const string PermBackup = "backup";
+    public const string PermLoad = "load";
+    public const string PermSnapshot = "snapshot";
+
+    private readonly Dictionary<string, string> store = new();
+    private readonly Dictionary<string, HashSet<string>> perms = new();
+
+    public CredentialsStore() { }
+
+    public static CredentialsStore NewCredentialsStoreFromFile(string path)
+    {
+        using var fs = File.OpenRead(path);
+        var c = new CredentialsStore();
+        c.Load(fs);
+        return c;
+    }
+
+    public void Load(Stream s)
+    {
+        using var doc = JsonDocument.Parse(s);
+        if (doc.RootElement.ValueKind != JsonValueKind.Array)
+            throw new JsonException("expected array");
+
+        foreach (var elem in doc.RootElement.EnumerateArray())
+        {
+            var cred = elem.Deserialize<Credential>();
+            if (cred == null) continue;
+            store[cred.Username] = cred.Password;
+            perms[cred.Username] = new HashSet<string>(cred.Perms ?? Array.Empty<string>());
+        }
+    }
+
+    public bool Check(string username, string password)
+    {
+        return store.TryGetValue(username, out var pw) && pw == password;
+    }
+
+    public (string Password, bool Ok) PasswordFor(string username)
+    {
+        if (store.TryGetValue(username, out var pw))
+            return (pw, true);
+        return (string.Empty, false);
+    }
+
+    public bool CheckRequest(IBasicAuther b)
+    {
+        var (u, p, ok) = b.BasicAuth();
+        return ok && Check(u, p);
+    }
+
+    public bool HasPerm(string username, string perm)
+    {
+        if (perms.TryGetValue(username, out var ps) && ps.Contains(perm))
+            return true;
+        if (perms.TryGetValue(AllUsers, out var ap) && ap.Contains(perm))
+            return true;
+        return false;
+    }
+
+    public bool HasAnyPerm(string username, params string[] perm)
+    {
+        foreach (var p in perm)
+            if (HasPerm(username, p))
+                return true;
+        return false;
+    }
+
+    public static bool AA(CredentialsStore? c, string username, string password, string perm)
+    {
+        if (c == null)
+            return true;
+        if (c.HasAnyPerm(AllUsers, perm, PermAll))
+            return true;
+        if (string.IsNullOrEmpty(username))
+            return false;
+        if (!c.Check(username, password))
+            return false;
+        return c.HasAnyPerm(username, perm, PermAll);
+    }
+
+    public bool HasPermRequest(IBasicAuther b, string perm)
+    {
+        var (u, _, ok) = b.BasicAuth();
+        return ok && HasPerm(u, perm);
+    }
+}

--- a/cs/rqbench/Duration.cs
+++ b/cs/rqbench/Duration.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+
+[JsonConverter(typeof(DurationJsonConverter))]
+public struct Duration
+{
+    public TimeSpan Value { get; set; }
+
+    public Duration(TimeSpan value) => Value = value;
+
+    public override string ToString() => Value.ToString();
+
+    public static implicit operator TimeSpan(Duration d) => d.Value;
+    public static implicit operator Duration(TimeSpan ts) => new Duration(ts);
+}
+
+public class DurationJsonConverter : JsonConverter<Duration>
+{
+    private static readonly Regex _regex = new("^(\\d+)(ms|s|m|h)$", RegexOptions.IgnoreCase);
+
+    public override Duration Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            long ns = reader.GetInt64();
+            return new Duration(TimeSpan.FromTicks(ns / 100));
+        }
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            string s = reader.GetString()!;
+            if (_regex.Match(s) is { Success: true } m)
+            {
+                long val = long.Parse(m.Groups[1].Value);
+                string unit = m.Groups[2].Value.ToLower();
+                TimeSpan ts = unit switch
+                {
+                    "ms" => TimeSpan.FromMilliseconds(val),
+                    "s" => TimeSpan.FromSeconds(val),
+                    "m" => TimeSpan.FromMinutes(val),
+                    "h" => TimeSpan.FromHours(val),
+                    _ => TimeSpan.Zero
+                };
+                return new Duration(ts);
+            }
+            if (TimeSpan.TryParse(s, out var ts2))
+                return new Duration(ts2);
+        }
+        throw new JsonException("invalid duration");
+    }
+
+    public override void Write(Utf8JsonWriter writer, Duration value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.Value.ToString());
+    }
+}
+
+[JsonConverter(typeof(StorageTypeJsonConverter))]
+public struct StorageType
+{
+    public string Value { get; set; }
+    public StorageType(string value) => Value = value;
+    public override string ToString() => Value;
+}
+
+public class StorageTypeJsonConverter : JsonConverter<StorageType>
+{
+    public override StorageType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+            throw new JsonException();
+        string s = reader.GetString()!;
+        if (s != "s3")
+            throw new JsonException("unsupported storage type");
+        return new StorageType(s);
+    }
+
+    public override void Write(Utf8JsonWriter writer, StorageType value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.Value);
+    }
+}

--- a/cs/rqbench/GzipUtil.cs
+++ b/cs/rqbench/GzipUtil.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+
+public static class GzipUtil
+{
+    public static string Gzip(string file)
+    {
+        using var input = File.OpenRead(file);
+        var tmp = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        using var output = File.Create(tmp);
+        using var gz = new GZipStream(output, CompressionLevel.Optimal);
+        input.CopyTo(gz);
+        return tmp;
+    }
+
+    public static string Gunzip(string file)
+    {
+        using var input = File.OpenRead(file);
+        using var gz = new GZipStream(input, CompressionMode.Decompress);
+        var tmp = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        using var output = File.Create(tmp);
+        gz.CopyTo(output);
+        return tmp;
+    }
+}

--- a/cs/rqbench/Humanize.cs
+++ b/cs/rqbench/Humanize.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+public static class Humanize
+{
+    private const double Base1000 = 1000.0;
+    private const double Base1024 = 1024.0;
+
+    private static readonly Dictionary<string, ulong> ByteSizeTable = new()
+    {
+        ["b"] = 1,
+        ["kib"] = 1UL << 10,
+        ["kb"] = 1000UL,
+        ["mib"] = 1UL << 20,
+        ["mb"] = 1000UL * 1000UL,
+        ["gib"] = 1UL << 30,
+        ["gb"] = 1000UL * 1000UL * 1000UL,
+        ["tib"] = 1UL << 40,
+        ["tb"] = 1000UL * 1000UL * 1000UL * 1000UL,
+        ["pib"] = 1UL << 50,
+        ["pb"] = 1000UL * 1000UL * 1000UL * 1000UL * 1000UL,
+        ["eib"] = 1UL << 60,
+        ["eb"] = 1000UL * 1000UL * 1000UL * 1000UL * 1000UL * 1000UL,
+        [""] = 1,
+        ["ki"] = 1UL << 10,
+        ["k"] = 1000UL,
+        ["mi"] = 1UL << 20,
+        ["m"] = 1000UL * 1000UL,
+        ["gi"] = 1UL << 30,
+        ["g"] = 1000UL * 1000UL * 1000UL,
+        ["ti"] = 1UL << 40,
+        ["t"] = 1000UL * 1000UL * 1000UL * 1000UL,
+        ["pi"] = 1UL << 50,
+        ["p"] = 1000UL * 1000UL * 1000UL * 1000UL * 1000UL,
+        ["ei"] = 1UL << 60,
+        ["e"] = 1000UL * 1000UL * 1000UL * 1000UL * 1000UL * 1000UL,
+    };
+
+    private static string HumanateBytes(ulong s, double b, string[] sizes)
+    {
+        if (s < 10)
+            return $"{s} B";
+        var e = Math.Floor(Math.Log(s) / Math.Log(b));
+        var suffix = sizes[(int)e];
+        var val = Math.Floor(s / Math.Pow(b, e) * 10 + 0.5) / 10;
+        string format = val < 10 ? "0.0" : "0";
+        return string.Format(CultureInfo.InvariantCulture, $"{{0:{format}}} {{1}}", val, suffix);
+    }
+
+    public static string Bytes(ulong s)
+    {
+        string[] sizes = { "B", "kB", "MB", "GB", "TB", "PB", "EB" };
+        return HumanateBytes(s, Base1000, sizes);
+    }
+
+    public static string IBytes(ulong s)
+    {
+        string[] sizes = { "B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB" };
+        return HumanateBytes(s, Base1024, sizes);
+    }
+
+    public static ulong ParseBytes(string s)
+    {
+        int last = 0;
+        bool hasComma = false;
+        foreach (char c in s)
+        {
+            if (!(char.IsDigit(c) || c == '.' || c == ','))
+                break;
+            if (c == ',')
+                hasComma = true;
+            last++;
+        }
+        string num = s.Substring(0, last);
+        if (hasComma)
+            num = num.Replace(",", "");
+        if (!double.TryParse(num, NumberStyles.Float, CultureInfo.InvariantCulture, out double f))
+            throw new FormatException("invalid number");
+        string extra = s.Substring(last).Trim().ToLowerInvariant();
+        if (ByteSizeTable.TryGetValue(extra, out ulong m))
+        {
+            f *= m;
+            if (f >= ulong.MaxValue)
+                throw new OverflowException("too large");
+            return (ulong)f;
+        }
+        throw new FormatException($"unhandled size name: {extra}");
+    }
+}

--- a/cs/rqbench/MD5Util.cs
+++ b/cs/rqbench/MD5Util.cs
@@ -1,0 +1,14 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+
+public static class MD5Util
+{
+    public static string MD5(string path)
+    {
+        using var stream = File.OpenRead(path);
+        using var md5 = System.Security.Cryptography.MD5.Create();
+        var hash = md5.ComputeHash(stream);
+        return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+    }
+}

--- a/cs/rqbench/MultiRSW.cs
+++ b/cs/rqbench/MultiRSW.cs
@@ -1,0 +1,61 @@
+using System;
+
+public class MultiRSW
+{
+    private bool _writerActive;
+    private int _numReaders;
+    private readonly object _lock = new();
+
+    public void BeginRead()
+    {
+        lock (_lock)
+        {
+            if (_writerActive)
+                throw new InvalidOperationException("MRSW conflict");
+            _numReaders++;
+        }
+    }
+
+    public void EndRead()
+    {
+        lock (_lock)
+        {
+            _numReaders--;
+            if (_numReaders < 0)
+                throw new InvalidOperationException("reader count went negative");
+        }
+    }
+
+    public void BeginWrite()
+    {
+        lock (_lock)
+        {
+            if (_writerActive || _numReaders > 0)
+                throw new InvalidOperationException("MRSW conflict");
+            _writerActive = true;
+        }
+    }
+
+    public void EndWrite()
+    {
+        lock (_lock)
+        {
+            if (!_writerActive)
+                throw new InvalidOperationException("write done received but no write is active");
+            _writerActive = false;
+        }
+    }
+
+    public void UpgradeToWriter()
+    {
+        lock (_lock)
+        {
+            if (_writerActive || _numReaders > 1)
+                throw new InvalidOperationException("MRSW conflict");
+            if (_numReaders == 0)
+                throw new InvalidOperationException("upgrade attempted with no readers");
+            _writerActive = true;
+            _numReaders = 0;
+        }
+    }
+}

--- a/cs/rqbench/NameAddress.cs
+++ b/cs/rqbench/NameAddress.cs
@@ -1,0 +1,13 @@
+public class NameAddress
+{
+    public string Address { get; }
+
+    public NameAddress(string address)
+    {
+        Address = address;
+    }
+
+    public string Network() => "tcp";
+
+    public override string ToString() => Address;
+}

--- a/cs/rqbench/NetworkReporter.cs
+++ b/cs/rqbench/NetworkReporter.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Net.NetworkInformation;
+
+public class NetworkReporter
+{
+    public Dictionary<string, object> Stats()
+    {
+        var interfaces = NetworkInterface.GetAllNetworkInterfaces();
+        var stats = new Dictionary<string, object>();
+        foreach (var i in interfaces)
+        {
+            var addresses = new List<Address>();
+            foreach (var addr in i.GetIPProperties().UnicastAddresses)
+            {
+                addresses.Add(new Address { Addr = addr.Address.ToString() });
+            }
+            stats[i.Name] = new InterfaceDetail
+            {
+                Flags = i.OperationalStatus.ToString(),
+                HardwareAddress = i.GetPhysicalAddress().ToString(),
+                Addresses = addresses
+            };
+        }
+        return new Dictionary<string, object> { { "interfaces", stats } };
+    }
+}
+
+public class Address
+{
+    public string Addr { get; set; } = string.Empty;
+}
+
+public class InterfaceDetail
+{
+    public string Flags { get; set; } = string.Empty;
+    public string HardwareAddress { get; set; } = string.Empty;
+    public List<Address> Addresses { get; set; } = new();
+}

--- a/cs/rqbench/PollTrue.cs
+++ b/cs/rqbench/PollTrue.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+public class PollTrue
+{
+    private readonly Func<bool> _fn;
+    private readonly TimeSpan _pollInterval;
+    private readonly TimeSpan _timeout;
+
+    public PollTrue(Func<bool> fn, TimeSpan pollInterval, TimeSpan timeout)
+    {
+        _fn = fn;
+        _pollInterval = pollInterval;
+        _timeout = timeout;
+    }
+
+    public void Run(string name)
+    {
+        var sw = Stopwatch.StartNew();
+        if (_fn())
+            return;
+        while (sw.Elapsed < _timeout)
+        {
+            Thread.Sleep(_pollInterval);
+            if (_fn())
+                return;
+        }
+        throw new TimeoutException($"timeout waiting for {name}");
+    }
+}

--- a/cs/rqbench/Progress.cs
+++ b/cs/rqbench/Progress.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+public interface ICounter
+{
+    long Count();
+}
+
+public delegate void LoggerFunc(long n);
+
+public class CountingReader : ICounter
+{
+    private readonly Stream _reader;
+    private long _count;
+
+    public CountingReader(Stream reader)
+    {
+        _reader = reader;
+    }
+
+    public int Read(byte[] buffer, int offset, int count)
+    {
+        int n = _reader.Read(buffer, offset, count);
+        Interlocked.Add(ref _count, n);
+        return n;
+    }
+
+    public long Count() => Interlocked.Read(ref _count);
+}
+
+public class CountingWriter : ICounter
+{
+    private readonly Stream _writer;
+    private long _count;
+
+    public CountingWriter(Stream writer)
+    {
+        _writer = writer;
+    }
+
+    public void Write(byte[] buffer, int offset, int count)
+    {
+        _writer.Write(buffer, offset, count);
+        Interlocked.Add(ref _count, count);
+    }
+
+    public long Count() => Interlocked.Read(ref _count);
+}
+
+public class CountingMonitor
+{
+    private const int CountingMonitorIntervalMs = 10_000;
+
+    private readonly LoggerFunc _loggerFn;
+    private readonly ICounter _ctr;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _runTask;
+    private bool _stopped;
+    private readonly object _lock = new();
+
+    private CountingMonitor(LoggerFunc loggerFn, ICounter ctr)
+    {
+        _loggerFn = loggerFn;
+        _ctr = ctr;
+        _runTask = Task.Run(Run);
+    }
+
+    public static CountingMonitor Start(LoggerFunc loggerFn, ICounter ctr)
+    {
+        return new CountingMonitor(loggerFn, ctr);
+    }
+
+    private async Task Run()
+    {
+        var token = _cts.Token;
+        try
+        {
+            while (!token.IsCancellationRequested)
+            {
+                await Task.Delay(CountingMonitorIntervalMs, token);
+                if (!token.IsCancellationRequested)
+                {
+                    _loggerFn(_ctr.Count());
+                }
+            }
+        }
+        catch (TaskCanceledException)
+        {
+        }
+    }
+
+    public void StopAndWait()
+    {
+        lock (_lock)
+        {
+            if (_stopped)
+                return;
+            _stopped = true;
+            _cts.Cancel();
+        }
+        _runTask.Wait();
+    }
+}

--- a/cs/rqbench/Queue.cs
+++ b/cs/rqbench/Queue.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+public sealed class FlushChannel
+{
+    private readonly TaskCompletionSource<bool> _tcs = new();
+    public Task Task => _tcs.Task;
+    public void Close() => _tcs.TrySetResult(true);
+}
+
+public class Request<T>
+{
+    public long SequenceNumber { get; set; }
+    public List<T> Objects { get; } = new();
+    internal List<FlushChannel> FlushChans { get; } = new();
+
+    public void Close()
+    {
+        foreach (var c in FlushChans)
+            c.Close();
+    }
+}
+
+internal class QueuedObjects<T>
+{
+    public long SequenceNumber;
+    public T[] Objects = Array.Empty<T>();
+    public FlushChannel? FlushChan;
+}
+
+public class Queue<T>
+{
+    private readonly int _batchSize;
+    private readonly TimeSpan _timeout;
+    private readonly Channel<QueuedObjects<T>> _batchCh;
+    private readonly Channel<bool> _flush;
+    private readonly Channel<Request<T>> _sendCh = Channel.CreateUnbounded<Request<T>>();
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _runTask;
+    private long _seqNum;
+    private int _depth;
+
+    public ChannelReader<Request<T>> C => _sendCh.Reader;
+
+    public Queue(int maxSize, int batchSize, TimeSpan timeout)
+    {
+        _batchSize = batchSize;
+        _timeout = timeout;
+        _batchCh = Channel.CreateBounded<QueuedObjects<T>>(maxSize);
+        _flush = Channel.CreateUnbounded<bool>();
+        _runTask = Task.Run(RunAsync);
+        _seqNum = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+    }
+
+    public async Task<long> WriteAsync(T[] objects, FlushChannel? c = null)
+    {
+        if (_cts.IsCancellationRequested)
+            throw new InvalidOperationException("queue is closed");
+
+        var q = new QueuedObjects<T> { Objects = objects, FlushChan = c };
+        q.SequenceNumber = Interlocked.Increment(ref _seqNum);
+        Interlocked.Increment(ref _depth);
+        await _batchCh.Writer.WriteAsync(q, _cts.Token);
+        return q.SequenceNumber;
+    }
+
+    public void Flush() => _flush.Writer.TryWrite(true);
+
+    public int Depth => _depth;
+
+    public Dictionary<string, object> Stats() => new()
+    {
+        ["batch_size"] = _batchSize,
+        ["timeout"] = _timeout.ToString()
+    };
+
+    public async Task CloseAsync()
+    {
+        _cts.Cancel();
+        _batchCh.Writer.TryComplete();
+        _flush.Writer.TryComplete();
+        await _runTask;
+    }
+
+    private async Task RunAsync()
+    {
+        var queued = new List<QueuedObjects<T>>();
+        var token = _cts.Token;
+        while (!token.IsCancellationRequested)
+        {
+            try
+            {
+                var readTask = _batchCh.Reader.ReadAsync(token).AsTask();
+                var flushTask = _flush.Reader.ReadAsync(token).AsTask();
+                var delayTask = Task.Delay(_timeout, token);
+                var completed = await Task.WhenAny(readTask, flushTask, delayTask);
+
+                if (completed == readTask)
+                {
+                    var obj = await readTask;
+                    queued.Add(obj);
+                    Interlocked.Decrement(ref _depth);
+                }
+                else if (completed == flushTask)
+                {
+                    _ = await flushTask;
+                }
+                // timeout handled by else
+
+                if (queued.Count >= _batchSize || completed == flushTask || completed == delayTask)
+                {
+                    if (queued.Count > 0)
+                    {
+                        var req = MergeQueued(queued);
+                        queued.Clear();
+                        await _sendCh.Writer.WriteAsync(req, token);
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        // flush remaining
+        if (queued.Count > 0)
+        {
+            var req = MergeQueued(queued);
+            await _sendCh.Writer.WriteAsync(req, CancellationToken.None);
+        }
+        _sendCh.Writer.TryComplete();
+    }
+
+    private static Request<T> MergeQueued(List<QueuedObjects<T>> qs)
+    {
+        var req = new Request<T>();
+        if (qs.Count > 0)
+            req.SequenceNumber = qs[0].SequenceNumber;
+
+        foreach (var q in qs)
+        {
+            if (q.SequenceNumber > req.SequenceNumber)
+                req.SequenceNumber = q.SequenceNumber;
+            req.Objects.AddRange(q.Objects);
+            if (q.FlushChan != null)
+                req.FlushChans.Add(q.FlushChan);
+        }
+        return req;
+    }
+}

--- a/cs/rqbench/RandomUtil.cs
+++ b/cs/rqbench/RandomUtil.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Text;
+
+static class RandomUtil
+{
+    private const string srcChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static readonly Random rng = new Random();
+
+    public static string StringN(int n)
+    {
+        var sb = new StringBuilder(n);
+        for (int i = 0; i < n; i++)
+        {
+            int idx = rng.Next(srcChars.Length);
+            sb.Append(srcChars[idx]);
+        }
+        return sb.ToString();
+    }
+
+    public static string String() => StringN(20);
+
+    public static string StringPattern(string s)
+    {
+        var sb = new StringBuilder(s.Length);
+        foreach (var ch in s)
+        {
+            if (ch == 'X' || ch == 'x')
+            {
+                int idx = rng.Next(srcChars.Length);
+                sb.Append(srcChars[idx]);
+            }
+            else
+            {
+                sb.Append(ch);
+            }
+        }
+        return sb.ToString();
+    }
+
+    public static byte[] Bytes(int n)
+    {
+        var b = new byte[n];
+        rng.NextBytes(b);
+        return b;
+    }
+
+    public static TimeSpan Jitter(TimeSpan d)
+    {
+        return d + TimeSpan.FromTicks((long)(rng.NextDouble() * d.Ticks));
+    }
+}

--- a/cs/rqbench/ReadyChannels.cs
+++ b/cs/rqbench/ReadyChannels.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class ReadyChannels
+{
+    private readonly object _lock = new();
+    private readonly List<Task> _tasks = new();
+    private long _closed;
+
+    public void Register(Task task)
+    {
+        lock (_lock)
+        {
+            _tasks.Add(task);
+        }
+        task.ContinueWith(_ => Interlocked.Increment(ref _closed));
+    }
+
+    public bool Ready()
+    {
+        lock (_lock)
+        {
+            return Interlocked.Read(ref _closed) == _tasks.Count;
+        }
+    }
+}

--- a/cs/rqbench/ReadyTarget.cs
+++ b/cs/rqbench/ReadyTarget.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public class ReadyTarget<T> where T : IComparable<T>
+{
+    private readonly object _lock = new();
+    private T _currentTarget = default!;
+    private readonly List<Subscriber> _subscribers = new();
+
+    public class Subscriber
+    {
+        public T Target { get; }
+        public TaskCompletionSource<object?> Tcs { get; }
+        public Task Task => Tcs.Task;
+
+        public Subscriber(T target)
+        {
+            Target = target;
+            Tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+    }
+
+    public Task SubscribeAsync(T target)
+    {
+        lock (_lock)
+        {
+            if (Comparer<T>.Default.Compare(target, _currentTarget) <= 0)
+            {
+                return Task.CompletedTask;
+            }
+            var sub = new Subscriber(target);
+            _subscribers.Add(sub);
+            return sub.Task;
+        }
+    }
+
+    public void Unsubscribe(Task task)
+    {
+        lock (_lock)
+        {
+            for (int i = 0; i < _subscribers.Count; i++)
+            {
+                if (_subscribers[i].Task == task)
+                {
+                    _subscribers.RemoveAt(i);
+                    break;
+                }
+            }
+        }
+    }
+
+    public void Signal(T index)
+    {
+        List<Subscriber>? toClose = null;
+        lock (_lock)
+        {
+            if (Comparer<T>.Default.Compare(index, _currentTarget) <= 0)
+                return;
+            _currentTarget = index;
+            for (int i = _subscribers.Count - 1; i >= 0; i--)
+            {
+                if (Comparer<T>.Default.Compare(index, _subscribers[i].Target) >= 0)
+                {
+                    toClose ??= new List<Subscriber>();
+                    toClose.Add(_subscribers[i]);
+                    _subscribers.RemoveAt(i);
+                }
+            }
+        }
+        if (toClose != null)
+        {
+            foreach (var s in toClose)
+            {
+                s.Tcs.TrySetResult(null);
+            }
+        }
+    }
+
+    public void Reset()
+    {
+        lock (_lock)
+        {
+            _currentTarget = default!;
+            _subscribers.Clear();
+        }
+    }
+
+    public int Len
+    {
+        get { lock (_lock) { return _subscribers.Count; } }
+    }
+}

--- a/cs/rqbench/RtlsConfig.cs
+++ b/cs/rqbench/RtlsConfig.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+public enum MTLSState
+{
+    Disabled,
+    Enabled
+}
+
+public static class RtlsConfig
+{
+    public static SslClientAuthenticationOptions CreateClientConfig(string certFile, string keyFile, string caCertFile, string serverName, bool noverify)
+    {
+        var opts = new SslClientAuthenticationOptions
+        {
+            TargetHost = serverName,
+            EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+            RemoteCertificateValidationCallback = noverify ? (_,_,_,_) => true : null
+        };
+        if (!string.IsNullOrEmpty(certFile) && !string.IsNullOrEmpty(keyFile))
+        {
+            opts.ClientCertificates = new X509CertificateCollection
+            {
+                X509Certificate2.CreateFromPemFile(certFile, keyFile)
+            };
+        }
+        if (!string.IsNullOrEmpty(caCertFile))
+        {
+            var ca = new X509Certificate2(File.ReadAllBytes(caCertFile));
+            opts.RemoteCertificateValidationCallback = (sender, cert, chain, errors) =>
+            {
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                chain.ChainPolicy.CustomTrustStore.Add(ca);
+                return chain.Build((X509Certificate2)cert!);
+            };
+        }
+        return opts;
+    }
+
+    public static SslServerAuthenticationOptions CreateServerConfig(string certFile, string keyFile, string caCertFile, MTLSState mtls)
+    {
+        var cert = X509Certificate2.CreateFromPemFile(certFile, keyFile);
+        var opts = new SslServerAuthenticationOptions
+        {
+            ServerCertificate = cert,
+            EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13
+        };
+        if (!string.IsNullOrEmpty(caCertFile))
+        {
+            var ca = new X509Certificate2(File.ReadAllBytes(caCertFile));
+            opts.ClientCertificateRequired = mtls == MTLSState.Enabled;
+            opts.RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+            {
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                chain.ChainPolicy.CustomTrustStore.Add(ca);
+                return chain.Build((X509Certificate2)certificate!);
+            };
+        }
+        else if (mtls == MTLSState.Enabled)
+        {
+            opts.ClientCertificateRequired = true;
+        }
+        return opts;
+    }
+}

--- a/cs/rqbench/TarGzipUtil.cs
+++ b/cs/rqbench/TarGzipUtil.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Formats.Tar;
+
+public static class TarGzipUtil
+{
+    public static bool IsTarGzipFile(string path)
+    {
+        try
+        {
+            using var f = File.OpenRead(path);
+            using var gz = new GZipStream(f, CompressionMode.Decompress);
+            // attempt to read first tar entry
+            using var reader = new TarReader(gz);
+            return reader.GetNextEntry() != null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public static bool TarGzipHasSubdirectories(string path)
+    {
+        using var f = File.OpenRead(path);
+        using var gz = new GZipStream(f, CompressionMode.Decompress);
+        using var reader = new TarReader(gz);
+        TarEntry? entry;
+        while ((entry = reader.GetNextEntry()) != null)
+        {
+            if (entry.EntryType == TarEntryType.Directory ||
+                entry.Name.Contains('/') || entry.Name.Contains('\\'))
+                return true;
+        }
+        return false;
+    }
+
+    public static void UntarGzipToDir(string path, string dir)
+    {
+        using var f = File.OpenRead(path);
+        using var gz = new GZipStream(f, CompressionMode.Decompress);
+        using var reader = new TarReader(gz);
+        Directory.CreateDirectory(dir);
+        TarEntry? entry;
+        var basePath = Path.GetFullPath(dir) + Path.DirectorySeparatorChar;
+        while ((entry = reader.GetNextEntry()) != null)
+        {
+            var dest = Path.Combine(dir, entry.Name);
+            dest = Path.GetFullPath(dest);
+            if (!dest.StartsWith(basePath, StringComparison.Ordinal))
+                throw new InvalidOperationException("invalid file path");
+            if (entry.EntryType == TarEntryType.Directory)
+            {
+                Directory.CreateDirectory(dest);
+            }
+            else
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+                using var outFile = File.Create(dest);
+                entry.DataStream.CopyTo(outFile);
+            }
+        }
+    }
+}

--- a/cs/rqbench/TcpDialer.cs
+++ b/cs/rqbench/TcpDialer.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Net.Security;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class TcpDialer
+{
+    private readonly byte _header;
+    private readonly SslClientAuthenticationOptions? _tlsOptions;
+
+    public TcpDialer(byte header, SslClientAuthenticationOptions? tlsOptions)
+    {
+        _header = header;
+        _tlsOptions = tlsOptions;
+    }
+
+    public async Task<Stream> DialAsync(string addr, TimeSpan timeout)
+    {
+        var parts = addr.Split(':');
+        if (parts.Length != 2)
+            throw new ArgumentException("addr must be host:port");
+        string host = parts[0];
+        int port = int.Parse(parts[1]);
+
+        using var cts = new CancellationTokenSource(timeout);
+        var client = new TcpClient();
+        try
+        {
+            await client.ConnectAsync(host, port, cts.Token);
+            Stream stream = client.GetStream();
+            if (_tlsOptions != null)
+            {
+                var ssl = new SslStream(stream, leaveInnerStreamOpen: false,
+                    _tlsOptions.RemoteCertificateValidationCallback);
+                await ssl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+                {
+                    TargetHost = host,
+                    ClientCertificates = _tlsOptions.ClientCertificates,
+                    EnabledSslProtocols = _tlsOptions.EnabledSslProtocols,
+                    CertificateRevocationCheckMode = _tlsOptions.CertificateRevocationCheckMode
+                }, cts.Token);
+                stream = ssl;
+            }
+            await stream.WriteAsync(new[] { _header }, 0, 1, cts.Token);
+            await stream.FlushAsync(cts.Token);
+            return stream;
+        }
+        catch
+        {
+            client.Close();
+            throw;
+        }
+    }
+}

--- a/cs/rqbench/WaitHelpers.cs
+++ b/cs/rqbench/WaitHelpers.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+
+public static class WaitHelpers
+{
+    public static async Task CloseOrTimeoutAsync(Task task, TimeSpan timeout)
+    {
+        var completed = await Task.WhenAny(task, Task.Delay(timeout));
+        if (completed != task)
+            throw new TimeoutException($"timeout after {timeout}");
+        await task; // propagate exceptions
+    }
+}

--- a/cs/rqbench/ZipUtil.cs
+++ b/cs/rqbench/ZipUtil.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+
+public static class ZipUtil
+{
+    public static bool IsZipFile(string path)
+    {
+        if (!File.Exists(path)) return false;
+        byte[] magic = new byte[4];
+        using var f = File.OpenRead(path);
+        if (f.Read(magic, 0, 4) != 4) return false;
+        return magic[0] == (byte)'P' && magic[1] == (byte)'K' && magic[2] == 3 && magic[3] == 4;
+    }
+
+    public static bool ZipHasSubdirectories(string path)
+    {
+        using var archive = ZipFile.OpenRead(path);
+        foreach (var entry in archive.Entries)
+        {
+            if (entry.FullName.EndsWith("/", StringComparison.Ordinal) ||
+                entry.FullName != Path.GetFileName(entry.FullName))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static void UnzipToDir(string path, string dir)
+    {
+        using var archive = ZipFile.OpenRead(path);
+        Directory.CreateDirectory(dir);
+        foreach (var entry in archive.Entries)
+        {
+            var destPath = Path.Combine(dir, entry.FullName);
+            if (!destPath.StartsWith(Path.GetFullPath(dir) + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+                throw new InvalidOperationException("invalid file path");
+            if (entry.FullName.EndsWith("/", StringComparison.Ordinal))
+            {
+                Directory.CreateDirectory(destPath);
+            }
+            else
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
+                entry.ExtractToFile(destPath, overwrite: true);
+            }
+        }
+    }
+}

--- a/cs/rqbench/http/Node.cs
+++ b/cs/rqbench/http/Node.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+
+namespace rqbench.Http
+{
+    public class Node
+    {
+        public string? ID { get; set; }
+        public string? APIAddr { get; set; }
+        public string? Addr { get; set; }
+        public string Version { get; set; } = string.Empty;
+        public bool Voter { get; set; }
+        public bool Reachable { get; set; }
+        public bool Leader { get; set; }
+        public double Time { get; set; }
+        public string TimeS { get; set; } = string.Empty;
+        public string Error { get; set; } = string.Empty;
+
+        private readonly object _lock = new();
+
+        public void SetError(string err)
+        {
+            lock (_lock)
+            {
+                Error = err;
+            }
+        }
+
+        public string ToJson()
+        {
+            lock (_lock)
+            {
+                return JsonSerializer.Serialize(this);
+            }
+        }
+    }
+
+    public static class NodeUtils
+    {
+        public static void TestNodes(IEnumerable<Node> nodes, Func<Node, bool> tester)
+        {
+            var threads = new List<Thread>();
+            foreach (var n in nodes)
+            {
+                var t = new Thread(() => tester(n));
+                threads.Add(t);
+                t.Start();
+            }
+            foreach (var t in threads)
+                t.Join();
+        }
+
+        public static void EncodeNodes(IEnumerable<Node> nodes, Stream output)
+        {
+            JsonSerializer.Serialize(output, new { nodes });
+        }
+
+        public static List<Node> DecodeNodes(Stream input)
+        {
+            using var doc = JsonDocument.Parse(input);
+            var list = new List<Node>();
+            if (doc.RootElement.TryGetProperty("nodes", out var arr) && arr.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var elem in arr.EnumerateArray())
+                {
+                    list.Add(JsonSerializer.Deserialize<Node>(elem.GetRawText())!);
+                }
+            }
+            return list;
+        }
+    }
+}

--- a/cs/rqbench/http/Preflight.cs
+++ b/cs/rqbench/http/Preflight.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Net.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace rqbench.Http
+{
+    public static class Preflight
+    {
+        private const string TestPath = "/status";
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(2);
+
+        public static (string? addr, bool ok) AnyServingHTTP(string[] addrs)
+        {
+            foreach (var a in addrs)
+            {
+                if (IsServingHTTP(a))
+                    return (a, true);
+            }
+            return (null, false);
+        }
+
+        public static bool IsServingHTTP(string addr)
+        {
+            var handler = new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = (msg, cert, chain, errors) => true
+            };
+            using var client = new HttpClient(handler) { Timeout = Timeout };
+
+            foreach (var u in new[] { $"http://{addr}{TestPath}", $"https://{addr}{TestPath}" })
+            {
+                try
+                {
+                    using var resp = client.GetAsync(u).Result;
+                    resp.Dispose();
+                    return true;
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/cs/rqbench/http/QueryParams.cs
+++ b/cs/rqbench/http/QueryParams.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Web;
+
+namespace rqbench.Http
+{
+    public class QueryParams : Dictionary<string, string>
+    {
+        public static QueryParams FromUri(Uri uri)
+        {
+            var qp = new QueryParams();
+            var parsed = HttpUtility.ParseQueryString(uri.Query);
+            foreach (string key in parsed)
+            {
+                if (key != null)
+                    qp[key] = parsed[key]!;
+            }
+            if (qp.ContainsKey("freshness_strict") && !qp.ContainsKey("freshness"))
+                throw new ArgumentException("freshness_strict requires freshness");
+            foreach (var k in new[] { "timeout", "freshness", "db_timeout", "linearizable_timeout" })
+            {
+                if (qp.TryGetValue(k, out var val))
+                    _ = TimeSpan.Parse(val);
+            }
+            foreach (var k in new[] { "retries", "trailing_logs" })
+            {
+                if (qp.TryGetValue(k, out var val))
+                    _ = int.Parse(val);
+            }
+            if (qp.TryGetValue("q", out var q) && q == "")
+                throw new ArgumentException("query parameter not set");
+            return qp;
+        }
+
+        public bool Timings() => ContainsKey("timings");
+        public bool Tx() => ContainsKey("transaction");
+        public bool Queue() => ContainsKey("queue");
+        public bool Pretty() => ContainsKey("pretty");
+        public bool Bypass() => ContainsKey("bypass");
+        public bool NoParse() => ContainsKey("noparse");
+        public bool Wait() => ContainsKey("wait");
+        public bool Associative() => ContainsKey("associative");
+        public bool BlobArray() => ContainsKey("blob_array");
+        public bool NoRewriteRandom() => ContainsKey("norwrandom");
+        public bool NoRewriteTime() => ContainsKey("norwtime");
+        public bool NonVoters() => ContainsKey("nonvoters");
+        public bool NoLeader() => ContainsKey("noleader");
+        public bool Redirect() => ContainsKey("redirect");
+        public bool Vacuum() => ContainsKey("vacuum");
+        public bool Compress() => ContainsKey("compress");
+
+        public string KeyParam => this.TryGetValue("key", out var v) ? v : string.Empty;
+
+        public TimeSpan DBTimeout(TimeSpan def)
+        {
+            if (TryGetValue("db_timeout", out var v) && TimeSpan.TryParse(v, out var t))
+                return t;
+            return def;
+        }
+
+        public TimeSpan LinearizableTimeout(TimeSpan def)
+        {
+            if (TryGetValue("linearizable_timeout", out var v) && TimeSpan.TryParse(v, out var t))
+                return t;
+            return def;
+        }
+
+        public string Query => this.TryGetValue("q", out var v) ? v : string.Empty;
+
+        public TimeSpan Freshness()
+        {
+            if (TryGetValue("freshness", out var v) && TimeSpan.TryParse(v, out var t))
+                return t;
+            return TimeSpan.Zero;
+        }
+
+        public bool FreshnessStrict() => ContainsKey("freshness_strict");
+
+        public bool Sync() => ContainsKey("sync");
+        public bool RaftIndex() => ContainsKey("raft_index");
+
+        public TimeSpan Timeout(TimeSpan def)
+        {
+            if (TryGetValue("timeout", out var v) && TimeSpan.TryParse(v, out var t))
+                return t;
+            return def;
+        }
+
+        public int Retries(int def)
+        {
+            if (TryGetValue("retries", out var v) && int.TryParse(v, out var r))
+                return r;
+            return def;
+        }
+
+        public int TrailingLogs(int def)
+        {
+            if (TryGetValue("trailing_logs", out var v) && int.TryParse(v, out var r))
+                return r;
+            return def;
+        }
+
+        public string Version() => this.TryGetValue("ver", out var v) ? v : string.Empty;
+    }
+}

--- a/cs/rqbench/http/RequestParser.cs
+++ b/cs/rqbench/http/RequestParser.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace rqbench.Http
+{
+    public static class RequestParser
+    {
+        public class Statement
+        {
+            public string Sql { get; set; } = string.Empty;
+            public List<Parameter> Parameters { get; } = new();
+        }
+
+        public class Parameter
+        {
+            public string Name { get; set; } = string.Empty;
+            public object? Value { get; set; }
+        }
+
+        public static List<Statement> ParseRequest(Stream stream)
+        {
+            if (stream == null)
+                throw new InvalidOperationException("no statements");
+
+            using var doc = JsonDocument.Parse(stream);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array)
+                throw new InvalidOperationException("invalid request");
+
+            var result = new List<Statement>();
+            foreach (var elem in doc.RootElement.EnumerateArray())
+            {
+                if (elem.ValueKind == JsonValueKind.String)
+                {
+                    result.Add(new Statement { Sql = elem.GetString()! });
+                }
+                else if (elem.ValueKind == JsonValueKind.Array)
+                {
+                    var items = new List<JsonElement>();
+                    foreach (var item in elem.EnumerateArray())
+                        items.Add(item);
+                    if (items.Count == 0 || items[0].ValueKind != JsonValueKind.String)
+                        throw new InvalidOperationException("invalid request");
+                    var stmt = new Statement { Sql = items[0].GetString()! };
+                    for (int i = 1; i < items.Count; i++)
+                    {
+                        stmt.Parameters.Add(MakeParameter(string.Empty, items[i]));
+                    }
+                    result.Add(stmt);
+                }
+                else
+                {
+                    throw new InvalidOperationException("invalid request");
+                }
+            }
+            if (result.Count == 0)
+                throw new InvalidOperationException("no statements");
+            return result;
+        }
+
+        private static Parameter MakeParameter(string name, JsonElement elem)
+        {
+            switch (elem.ValueKind)
+            {
+                case JsonValueKind.Number:
+                    if (elem.TryGetInt64(out long i64))
+                        return new Parameter { Name = name, Value = i64 };
+                    return new Parameter { Name = name, Value = elem.GetDouble() };
+                case JsonValueKind.String:
+                    return new Parameter { Name = name, Value = elem.GetString() };
+                case JsonValueKind.True:
+                case JsonValueKind.False:
+                    return new Parameter { Name = name, Value = elem.GetBoolean() };
+                case JsonValueKind.Null:
+                    return new Parameter { Name = name, Value = null };
+                case JsonValueKind.Array:
+                    var bytes = new List<byte>();
+                    foreach (var it in elem.EnumerateArray())
+                    {
+                        if (it.TryGetInt32(out int b) && b >= 0 && b <= 255)
+                            bytes.Add((byte)b);
+                        else
+                            throw new InvalidOperationException("unsupported type");
+                    }
+                    return new Parameter { Name = name, Value = bytes.ToArray() };
+                case JsonValueKind.Object:
+                    var p = new Parameter { Name = name };
+                    foreach (var prop in elem.EnumerateObject())
+                        p = MakeParameter(prop.Name, prop.Value);
+                    return p;
+                default:
+                    throw new InvalidOperationException("unsupported type");
+            }
+        }
+    }
+}

--- a/cs/rqbench/http/UrlUtil.cs
+++ b/cs/rqbench/http/UrlUtil.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Net;
+using System.Text;
+
+namespace rqbench.Http
+{
+    public static class UrlUtil
+    {
+        public static string NormalizeAddr(string addr)
+        {
+            if (!addr.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+                !addr.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                return $"http://{addr}";
+            }
+            return addr;
+        }
+
+        public static string EnsureHTTPS(string addr)
+        {
+            if (!addr.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+                !addr.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                return $"https://{addr}";
+            }
+            if (addr.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+                return "https://" + addr.Substring("http://".Length);
+            return addr;
+        }
+
+        public static bool CheckHTTPS(string addr)
+        {
+            return addr.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static string AddBasicAuth(string joinAddr, string username, string password, out Exception? error)
+        {
+            error = null;
+            if (string.IsNullOrEmpty(username))
+                return joinAddr;
+            if (!Uri.TryCreate(joinAddr, UriKind.Absolute, out var u))
+            {
+                error = new UriFormatException("invalid address");
+                return string.Empty;
+            }
+            if (!string.IsNullOrEmpty(u.UserInfo))
+            {
+                error = new InvalidOperationException("userinfo exists");
+                return string.Empty;
+            }
+            var builder = new UriBuilder(u)
+            {
+                UserName = username,
+                Password = password
+            };
+            return builder.Uri.ToString();
+        }
+
+        public static string RemoveBasicAuth(string u)
+        {
+            if (!Uri.TryCreate(u, UriKind.Absolute, out var uri))
+                return u;
+            var builder = new UriBuilder(uri)
+            {
+                UserName = string.Empty,
+                Password = string.Empty
+            };
+            return builder.Uri.ToString();
+        }
+    }
+}

--- a/cs/rqbench/rqbench.csproj
+++ b/cs/rqbench/rqbench.csproj
@@ -6,5 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.IO.Compression.ZipFile" Version="7.0.0" />
+    <PackageReference Include="System.Formats.Tar" Version="7.0.0" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- port a batching `Queue` with flush support
- add TLS helpers including certificate reloader and config builder
- provide certificate generation helper functions
- port HTTP utilities like Preflight checks and URL helpers

## Testing
- `dotnet build cs/rqbench/rqbench.csproj` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e836e8aec83259435e529ccc5fe7b